### PR TITLE
ロードストーンのHTTPS対応

### DIFF
--- a/GooglePicker.js
+++ b/GooglePicker.js
@@ -60,6 +60,7 @@ var GooglePicker = (function() {
                 .setCallback(pickerCallback)
                 .setOAuthToken(accessToken)
                 .setDeveloperKey(API_KEY)
+                .setOrigin('https://jp.finalfantasyxiv.com')
                 .build();
             picker.setVisible(true);
             
@@ -86,7 +87,7 @@ var GooglePicker = (function() {
          * スクリプトロード完了通知
          */
         sendLoadComplete: function() {
-            window.postMessage([SCRIPT_LOAD_MSG,''], 'http://jp.finalfantasyxiv.com');
+            window.postMessage([SCRIPT_LOAD_MSG,''], 'https://jp.finalfantasyxiv.com');
         }
     };
     return global;


### PR DESCRIPTION
ロードストーンがHTTPからHTTPSに変わった影響で動作しなくなったため、
HTTPSで動作するように修正